### PR TITLE
fixing ansible spacing error

### DIFF
--- a/install/targets.yml
+++ b/install/targets.yml
@@ -24,12 +24,12 @@
       path: /usr/bin/docker-compose
     register: stat_docker_compose
 
-- name: install docker-compose
-  get_url:
-    url: https://github.com/docker/compose/releases/download/1.14.0/docker-compose-Linux-x86_64
-    dest: /usr/bin/docker-compose
-    mode: 0744
-  when: stat_docker_compose.stat.exists == False
+  - name: install docker-compose
+    get_url:
+      url: https://github.com/docker/compose/releases/download/1.14.0/docker-compose-Linux-x86_64
+      dest: /usr/bin/docker-compose
+      mode: 0744
+    when: stat_docker_compose.stat.exists == False
 
 
   - name: set permissions for docker-compose


### PR DESCRIPTION
fixing lines https://github.com/SamuraiWTF/samuraiwtf/blob/53f39bac14fb8ff3d2492b752f4ff1dafb5ffc9a/install/targets.yml#L27-L32

since ansible is white space delimited it didn't like that these lines didn't match up.