### PR TITLE
changing to node10

### DIFF
--- a/install/targets.yml
+++ b/install/targets.yml
@@ -49,7 +49,7 @@
 
   - name: Download npm installer
     get_url:
-      url: https://deb.nodesource.com/setup_11.x
+      url: https://deb.nodesource.com/setup_10.x
       dest: /tmp/npm_setup.sh
       mode: 0744
     when: stat_npm.stat.exists == False


### PR DESCRIPTION
When doing #84, I changed it to the node version 10 download, and didn't realize we were pulling the https://deb.nodesource.com/setup_11.x install script. So now, I changed it to the https://deb.nodesource.com/setup_10.x script which should install the proper version for starting juice-shop. It was working on my computer, so please check :smile: 