### PR TITLE
Fix Dojo DB connection issues

### DIFF
--- a/install/targets/samurai-dojo/samurai-dojo-tasks.yml
+++ b/install/targets/samurai-dojo/samurai-dojo-tasks.yml
@@ -66,30 +66,6 @@
     mode: 0744
   become: yes
 
-- name: Start samurai-dojo docker service
-  docker_service:
-    project_src: /opt/targets/samuraidojo
-    restarted: true
-  register: output
-
-- debug:
-    var: output
-
-- assert:
-    that:
-      - "basicdb.samuraidojo_basicdb_1.state.running"
-      - "basicphp.samuraidojo_basicphp_1.state.running"
-
-- name: Stop samurai-dojo docker service
-  docker_service:
-    project_src: /opt/targets/samuraidojo
-    stopped: true
-
-- assert:
-    that:
-      - "not basicdb.samuraidojo_basicdb_1.state.running"
-      - "not basicphp.samuraidojo_basicphp_1.state.running"
-
 - name: Create Samurai Dojo target service descriptor
   copy:
     dest: /etc/systemd/system/wtf-dojo.service

--- a/install/tools.yml
+++ b/install/tools.yml
@@ -10,5 +10,5 @@
   - import_tasks: tools/nikto-tasks.yml
   - import_tasks: tools/sqlmap-tasks.yml
   - import_tasks: tools/wordlists-tasks.yml
-  - import_tasks: tools/zap-tasks.yml
+#  - import_tasks: tools/zap-tasks.yml
   - import_tasks: tools/postman-tasks.yml


### PR DESCRIPTION
## Change Log

`samurai-dojo-tasks.yml` was starting dojo using docker-compose and then again using the systemd service descriptor which seemed to cause issues with provisioning the databases. Removing the ansible tasks which started dojo using docker-compose appears to have fixed the issue. 

Additionally commented out the provisioning of Zap proxy as it was failing on my end confounding the root cause of the DB issues.  This may need to be a separate issue if it's reproducible.

## Reviewer instructions

1. checkout the `dojo_db_conn_fix` branch
2. backup any current versions of samurai (or don't)
3. run `vagrant destroy -f` and then `vagrant up`
4. Log into the vm as samurai
5. browse to `http://dojo-basic.wtf` and `http://dojo-scavenger.wtf` and make sure the DB seems to be working
6. If you want to be *extra* certain run `sudo docker exec -it samuraidojo_basicdb_1 /bin/bash` then `mysql -uroot -psamurai` and finally `show databases;` to see if the database was actually created.
7. Do the above again but replace `samuraidojo_basicdb_1` with `samuraidojo_scavengerdb_1`