### PR TITLE
fixing systemd service definitions

### DIFF
--- a/install/targets/dvwa/dvwa-tasks.yml
+++ b/install/targets/dvwa/dvwa-tasks.yml
@@ -4,10 +4,9 @@
     state: started
     enabled: yes
 
-- name: Install DVWA docker container
-  docker_container:
-    name: dvwa
-    image: bit0pus/docker-dvwa
+- name: Pulling DVWA docker container
+  docker_image:
+    name: bit0pus/docker-dvwa
 
 - name: Create service descriptor
   copy:
@@ -20,10 +19,8 @@
       [Service]
       TimeoutStartSec=0
       Restart=always
-      ExecStartPre=-/usr/bin/docker stop -t 10 %n
-      ExecStart=/usr/bin/docker run --rm -p 31000:80 -p 33006:3306 --name %n bit0pus/docker-dvwa
-      ExecStop=/usr/bin/docker stop -t 10 %n
-      ExecStopPost=/usr/bin/docker stop -t 10 dvwa
+      ExecStart=/usr/bin/docker run --rm -p 31000:80 -p 33006:3306 --name %N bit0pus/docker-dvwa
+      ExecStop=/usr/bin/docker stop -t 10 %N
       [Install]
       WantedBy=multi-user.target
     mode: 0744

--- a/install/targets/mutillidae/mutillidae-tasks.yml
+++ b/install/targets/mutillidae/mutillidae-tasks.yml
@@ -4,10 +4,9 @@
     state: started
     enabled: yes
 
-- name: Install Mutillidae docker container
-  docker_container:
-    name: mutillidae
-    image: bit0pus/docker-mutillidae
+- name: Pulling Mutillidae docker container
+  docker_image:
+    name: bit0pus/docker-mutillidae
 
 - name: Create service descriptor
   copy:
@@ -20,10 +19,8 @@
       [Service]
       TimeoutStartSec=0
       Restart=always
-      ExecStartPre=/usr/bin/docker stop -t 10 %n
-      ExecStart=/usr/bin/docker run --rm -p 33080:80 -p 22222:22 -p 33333:3306 --name bit0pus/docker-mutillidae
-      ExecStop=/usr/bin/docker stop -t 10 %n
-      ExecStopPost=/usr/bin/docker stop -t 10 mutillidae
+      ExecStart=/usr/bin/docker run --rm -p 33080:80 -p 22222:22 -p 33333:3306 --name %N bit0pus/docker-mutillidae
+      ExecStop=/usr/bin/docker stop -t 10 %N
       [Install]
       WantedBy=multi-user.target
     mode: 0744


### PR DESCRIPTION
## Observed 
- Failure to start the mutillidae service which caused :arrow_right: failure to finish install
![image](https://user-images.githubusercontent.com/10230166/73149672-7162f380-4090-11ea-843e-114d78fbe5bb.png)

- multiple of dvwa container
![image](https://user-images.githubusercontent.com/10230166/73149715-90fa1c00-4090-11ea-92de-1999b8f96671.png)


## Solution
1. Don't use the `docker_container` module to install the docker container, because that will "manage" you docker container. It will start running the docker container for you, so instead if you use the `docker_image` it will simply do the equivalent of `docker pull`
2. the systemd service file was missing a value for the argument of `--name` in the mutillidae docker ExecStart command.
3. There were actually multiple dvwa containers that were getting launched. 1 when the `docker_container` module was used (named dvwa) and another when the systemd service was started (name wtf-dvwa.service (because of the `%n` and not using `%N`)).
4. The `ExecStartPre` and `ExecStopPost` were both unnecessary since we are only launching a single container with the ExecStart and aren't trying to affect any other containers.

**NOTE:** the docker containers names are prepended with `wtf-`, because that is what the service name file has in it (wtf-dvwa & wtf-mutillidae).

## Extra info
So, for the longest time I was struggling to finalized the `docker_image` module, and I figured out that we are currently running ansible 2.7 (latest is 2.9) in the debian-10 bento box. So, we might want to figure out another method of installation, something that will grab a more up to date version: https://www.vagrantup.com/docs/provisioning/ansible_local.html