### PR TITLE
do apt-get update before installing deps in provision.sh

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -2,6 +2,9 @@
 
 echo "Vagrant Provisioning for Ubuntu"
 
+export DEBIAN_FRONTEND='noninteractive'
+apt-get update
+
 apt install -y python-is-python3 jq libnss3-tools gnome-shell-extension-arc-menu gnome-tweaks
 
 chown samurai:samurai /opt/katana


### PR DESCRIPTION
apt-get update was missing from provision.sh before attempting to use apt install to install deps.
This broke several things. It was discovered when testing a katana fix for Juice-Shop because a broken package cause jq not to install which cause wget to fail on downloading mkcert, which then caused nginx to crash when trying to start after being configured to service juice-shop via TLS.

This is related to the following katana PR - https://github.com/SamuraiWTF/katana/pull/33