### PR TITLE
Update to include vmware workstation in vagrant file

### DIFF
--- a/ubuntu-20/README.md
+++ b/ubuntu-20/README.md
@@ -18,7 +18,7 @@ We use Vagrant to build this VM, so that is the prerequisite. Hyper-V is the def
 1. To allow vagrant to modify VMware workstation install the plugin [HERE](https://developer.hashicorp.com/vagrant/docs/providers/vmware/vagrant-vmware-utility) or with Chocolatey `choco install vagrant-vmware-utility`
 2. To install VMware provider to [Vagrant](https://developer.hashicorp.com/vagrant/docs/providers/vmware/installation) use the following command `vagrant plugin install vagrant-vmware-desktop` 
 3. From the command line, navigate to this folder and run `vagrant up --provider=vmware_desktop`
-4. The VirtualBox provider will automatically open a new window. Ignore that window for now and wait for the script to complete. This may take a long time (20-30 minutes, possibly longer when running alongside Hyper-V).
+4. The VMware provider will automatically open a new window/vm in vmware workstation. Ignore that window for now and wait for the script to complete. This may take a long time (20-30 minutes, possibly longer when running alongside Hyper-V).
 5. Run `vagrant reload` to restart the VM and ensure all the configuration is in place during boot.
 6. Connect to the VM and login in with user: _samurai_ , password: _samurai_
 

--- a/ubuntu-20/README.md
+++ b/ubuntu-20/README.md
@@ -14,6 +14,14 @@ We use Vagrant to build this VM, so that is the prerequisite. Hyper-V is the def
 3. Run `vagrant reload` to restart the VM and ensure all the configuration is in place during boot.
 4. Connect to the VM and login in with user: _samurai_ , password: _samurai_
 
+## VMware Workstation
+1. To allow vagrant to modify VMware workstation install the plugin [HERE](https://developer.hashicorp.com/vagrant/docs/providers/vmware/vagrant-vmware-utility) or with Chocolatey `choco install vagrant-vmware-utility`
+2. To install VMware provider to [Vagrant](https://developer.hashicorp.com/vagrant/docs/providers/vmware/installation) use the following command `vagrant plugin install vagrant-vmware-desktop` 
+3. From the command line, navigate to this folder and run `vagrant up --provider=vmware_desktop`
+4. The VirtualBox provider will automatically open a new window. Ignore that window for now and wait for the script to complete. This may take a long time (20-30 minutes, possibly longer when running alongside Hyper-V).
+5. Run `vagrant reload` to restart the VM and ensure all the configuration is in place during boot.
+6. Connect to the VM and login in with user: _samurai_ , password: _samurai_
+
 # Final Setup
 If you intend to make this VM available to others, for example as a lab environment for a class, there are a few other recommended steps:
 

--- a/ubuntu-20/Vagrantfile
+++ b/ubuntu-20/Vagrantfile
@@ -77,6 +77,14 @@ Vagrant.configure("2") do |config|
         vb.customize ["modifyvm", :id, "--accelerate2dvideo", "on"]
       end
 
+      samuraiwtf.vm.provider "vmware_desktop" do |v|
+        v.vmx["name"] = "SamuraiWTF-5.3"
+        v.vmx["memsize"] = "4096"
+        v.vmx["numvcpus"] = "2"
+        v.vmx["cpuid.coresPerSocket"] = "1"
+        v.gui = true
+       end      
+  
   end
 
   #   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
Left instructions and updated vagrant file to implement vmware workstation. This also works with vmware fusion and desktop. So this should work with the free version's fine as Vagrant open sourced the provider. 

There are plugins required to install on windows to get it to work and setup the provider, those are updated in the readme. 